### PR TITLE
Features/rol facturas

### DIFF
--- a/authorization/forms/groups.py
+++ b/authorization/forms/groups.py
@@ -2,6 +2,7 @@
 
 # Django
 from django import forms
+from django.contrib.auth.models import Group
 
 # Forms
 from crispy_forms.bootstrap import FormActions
@@ -10,7 +11,9 @@ from crispy_forms.layout import Submit, Fieldset, Layout, Div, Reset
 
 # Models
 from authorization.models import Permission
-from django.contrib.auth.models import Group
+
+# Core
+from core.utils.strings import HELP_TEXT_MULTIPLE_CHOICE
 
 
 class GroupForm(forms.ModelForm):
@@ -40,16 +43,17 @@ class GroupForm(forms.ModelForm):
         )
 
     permissions = forms.ModelMultipleChoiceField(
-         queryset=Permission.objects.filter(
-             content_type__app_label__in=['accounting', 'auth', 'authorization', 'core'],
-             content_type__model__in=[
-                 'archivo',
-                 'cliente', 'factura', 'ordencompra', 'cobranza',
-                 'proveedor', 'facturaproveedor', 'pago',
-                 'mediopago',
-                 'permission', 'user', 'group'
-             ]
-         ).order_by('content_type__model', 'name')
+        help_text=HELP_TEXT_MULTIPLE_CHOICE,
+        queryset=Permission.objects.filter(
+            content_type__app_label__in=['accounting', 'auth', 'authorization', 'core'],
+            content_type__model__in=[
+                'archivo',
+                'cliente', 'factura', 'ordencompra', 'cobranza',
+                'proveedor', 'facturaproveedor', 'pago',
+                'mediopago',
+                'permission', 'user', 'group'
+            ]
+        ).order_by('content_type__model', 'name')
     )
 
     class Meta:

--- a/authorization/forms/users.py
+++ b/authorization/forms/users.py
@@ -19,7 +19,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, Fieldset, Layout, Reset, Submit
 
 # Utils
-from core.utils.strings import HELP_TEXT_PASSWORD_CONFIRMATION, HELP_TEXT_USERNAME
+from core.utils.strings import HELP_TEXT_MULTIPLE_CHOICE, HELP_TEXT_PASSWORD_CONFIRMATION, HELP_TEXT_USERNAME
 
 User = get_user_model()
 
@@ -104,6 +104,7 @@ class UserCreateForm(forms.ModelForm):
     is_superuser = forms.BooleanField(required=False, label='Administrador')
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.order_by('name'),
+        help_text=HELP_TEXT_MULTIPLE_CHOICE,
         label='Grupos',
         required=False
     )
@@ -150,7 +151,7 @@ class UserCreateForm(forms.ModelForm):
 
         return data
 
-    def save(self):
+    def save(self, commit=True):
         """Create user."""
         data = self.cleaned_data
         data.pop('password_confirmation')
@@ -239,6 +240,7 @@ class UserUpdateForm(forms.ModelForm):
 
     groups = forms.ModelMultipleChoiceField(
         queryset=Group.objects.order_by('name'),
+        help_text=HELP_TEXT_MULTIPLE_CHOICE,
         label='Grupos',
         required=False
     )

--- a/authorization/management/commands/add_permissions.py
+++ b/authorization/management/commands/add_permissions.py
@@ -49,6 +49,30 @@ class Command(BaseCommand):
                  'content_type': ContentType.objects.get(model='factura')},
                 {'name': 'Puede ver reportes de Facturas A Proveedores', 'codename': 'view_reports_facturaproveedor',
                  'content_type': ContentType.objects.get(model='facturaproveedor')},
+                # Facturas a clientes
+                {'name': 'Puede editar número de Facturas A Clientes', 'codename': 'change_nro_factura',
+                 'content_type': ContentType.objects.get(model='factura')},
+                {'name': 'Puede editar neto de Facturas A Clientes', 'codename': 'change_neto_factura',
+                 'content_type': ContentType.objects.get(model='factura')},
+                {'name': 'Puede editar iva de Facturas A Clientes', 'codename': 'change_iva_factura',
+                 'content_type': ContentType.objects.get(model='factura')},
+                {'name': 'Puede editar total de Facturas A Clientes', 'codename': 'change_total_factura',
+                 'content_type': ContentType.objects.get(model='factura')},
+                {'name': 'Puede editar archivos de Facturas A Clientes', 'codename': 'change_archivos_factura',
+                 'content_type': ContentType.objects.get(model='factura')},
+                # Facturas a proveedores
+                {'name': 'Puede editar número de Facturas A Proveedores', 'codename': 'change_nro_facturaproveedor',
+                 'content_type': ContentType.objects.get(model='facturaproveedor')},
+                {'name': 'Puede editar neto de Facturas A Proveedores', 'codename': 'change_neto_facturaproveedor',
+                 'content_type': ContentType.objects.get(model='facturaproveedor')},
+                {'name': 'Puede editar iva de Facturas A Proveedores', 'codename': 'change_iva_facturaproveedor',
+                 'content_type': ContentType.objects.get(model='facturaproveedor')},
+                {'name': 'Puede editar total de Facturas A Proveedores', 'codename': 'change_total_facturaproveedor',
+                 'content_type': ContentType.objects.get(model='facturaproveedor')},
+                {'name': 'Puede editar archivos de Facturas A Proveedores',
+                 'codename': 'change_archivos_facturaproveedor',
+                 'content_type': ContentType.objects.get(model='facturaproveedor')},
+
             ]
 
             for permission in permissions:

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,5 +1,6 @@
 """Módulo de Constantes."""
 
+# No modificar el orden
 MONEDAS = (
     ('P', '$'),
     ('D', 'U$D')

--- a/core/forms/clientes.py
+++ b/core/forms/clientes.py
@@ -235,6 +235,14 @@ class FacturaForm(forms.ModelForm):
                 raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
         return total
 
+    def clean_archivos(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        archivos = self.files.getlist('archivos')
+        if not self.user.has_perm('core.change_archivos_factura'):
+            if archivos:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return archivos
+
     def save(self, commit=True):
         """Guarda los datos recibidos del formulario."""
         data = self.cleaned_data

--- a/core/forms/clientes.py
+++ b/core/forms/clientes.py
@@ -231,7 +231,7 @@ class FacturaForm(forms.ModelForm):
             # Verifico que el total calculado no haya sido modificado
             neto = float(self.instance.neto)
             total_calculado = neto + (self.instance.iva / 100) * neto
-            if total_calculado != total:
+            if total_calculado != float(total):
                 raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
         return total
 

--- a/core/forms/proveedores.py
+++ b/core/forms/proveedores.py
@@ -239,6 +239,14 @@ class FacturaProveedorForm(forms.ModelForm):
                 raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
         return total
 
+    def clean_archivos(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        archivos = self.files.getlist('archivos')
+        if not self.user.has_perm('core.change_archivos_facturaproveedor'):
+            if archivos:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return archivos
+
     def save(self, commit=True):
         """Guarda los datos del formulario."""
         data = self.cleaned_data

--- a/core/forms/proveedores.py
+++ b/core/forms/proveedores.py
@@ -195,7 +195,6 @@ class FacturaProveedorForm(forms.ModelForm):
             'moneda', 'neto', 'iva', 'total', 'cobrado', 'archivos'
         )
 
-
     def clean_numero(self):
         """Verifica si el usuario tiene permisos para editar el campo."""
         numero = self.cleaned_data['numero']
@@ -236,7 +235,7 @@ class FacturaProveedorForm(forms.ModelForm):
             # Verifico que el total calculado no haya sido modificado
             neto = float(self.instance.neto)
             total_calculado = neto + (self.instance.iva / 100) * neto
-            if total_calculado != total:
+            if total_calculado != float(total):
                 raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
         return total
 

--- a/core/forms/proveedores.py
+++ b/core/forms/proveedores.py
@@ -8,10 +8,11 @@ from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Fieldset, Layout, HTML, Div, Reset
 
-# Models
+# Core
 from core.models.archivo import Archivo
 from core.models.entidad import Distrito, Localidad
 from core.models.proveedor import FacturaProveedor, Proveedor
+from core.utils.strings import MESSAGE_PERMISSION_ERROR
 
 
 class ProveedorForm(forms.ModelForm):
@@ -107,7 +108,20 @@ class FacturaProveedorForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         """Inicialización de formulario."""
+        self.user = kwargs.pop('user')
         super().__init__(*args, **kwargs)
+
+        # Permisos
+        if not self.user.has_perm('core.change_nro_facturaproveedor'):
+            self.fields['numero'].widget.attrs['readonly'] = True
+        if not self.user.has_perm('core.change_neto_facturaproveedor'):
+            self.fields['moneda'].widget.attrs['readonly'] = True
+            self.fields['neto'].widget.attrs['readonly'] = True
+        if not self.user.has_perm('core.change_iva_facturaproveedor'):
+            self.fields['iva'].widget.attrs['readonly'] = True
+        if not self.user.has_perm('core.change_total_facturaproveedor'):
+            self.fields['total'].widget.attrs['readonly'] = True
+
         self.fields['numero'].label = 'Número de factura'
         self.fields['factura'].label = 'Factura de cliente'
         self.fields['cobrado'].label = 'Pagado'
@@ -181,7 +195,52 @@ class FacturaProveedorForm(forms.ModelForm):
             'moneda', 'neto', 'iva', 'total', 'cobrado', 'archivos'
         )
 
-    def save(self, *args, **kwargs):
+
+    def clean_numero(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        numero = self.cleaned_data['numero']
+        if not self.user.has_perm('core.change_nro_facturaproveedor'):
+            if self.instance.numero != numero:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return numero
+
+    def clean_moneda(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        moneda = self.cleaned_data['moneda']
+        if not self.user.has_perm('core.change_neto_facturaproveedor'):
+            if self.instance.moneda != moneda:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return moneda
+
+    def clean_neto(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        neto = self.cleaned_data['neto']
+        if not self.user.has_perm('core.change_neto_facturaproveedor'):
+            if neto not in [self.fields['neto'].initial, self.instance.neto]:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return neto
+
+    def clean_iva(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        iva = self.cleaned_data['iva']
+        if not self.user.has_perm('core.change_iva_facturaproveedor'):
+            if self.fields['iva'].initial != iva:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return iva
+
+    def clean_total(self):
+        """Verifica si el usuario tiene permisos para editar el campo."""
+        total = self.cleaned_data['total']
+
+        if not self.user.has_perm('core.change_total_facturaproveedor'):
+            # Verifico que el total calculado no haya sido modificado
+            neto = float(self.instance.neto)
+            total_calculado = neto + (self.instance.iva / 100) * neto
+            if total_calculado != total:
+                raise forms.ValidationError(MESSAGE_PERMISSION_ERROR)
+        return total
+
+    def save(self, commit=True):
         """Guarda los datos del formulario."""
         data = self.cleaned_data
         data.pop('archivos')

--- a/core/templates/core/facturacliente_form.html
+++ b/core/templates/core/facturacliente_form.html
@@ -40,6 +40,11 @@
 {% endblock %}
 
 {% block extra_js %}
+var permAddArchivos = '{{ perms.core.add_archivos_factura }}';
+if (permAddArchivos !== 'True'){
+    $('input[name="archivos"]').prop('disabled', true);
+}
+
 $('#id_fecha').datepicker({format: 'dd/mm/yyyy', language: 'es', todayHighlight: true});
 $('#id_cliente').select2({allowClear: true, language: 'es'});
 $('#id_cliente').change(function(){

--- a/core/templates/core/facturacliente_form.html
+++ b/core/templates/core/facturacliente_form.html
@@ -40,7 +40,7 @@
 {% endblock %}
 
 {% block extra_js %}
-var permAddArchivos = '{{ perms.core.add_archivos_factura }}';
+var permAddArchivos = '{{ perms.core.change_archivos_factura }}';
 if (permAddArchivos !== 'True'){
     $('input[name="archivos"]').prop('disabled', true);
 }

--- a/core/templates/core/facturaproveedor_form.html
+++ b/core/templates/core/facturaproveedor_form.html
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block extra_js %}
-var permAddArchivos = '{{ perms.core.add_archivos_facturaproveedor }}';
+var permAddArchivos = '{{ perms.core.change_archivos_facturaproveedor }}';
 if (permAddArchivos !== 'True'){
     $('input[name="archivos"]').prop('disabled', true);
 }

--- a/core/templates/core/facturaproveedor_form.html
+++ b/core/templates/core/facturaproveedor_form.html
@@ -39,6 +39,10 @@
 {% endblock %}
 
 {% block extra_js %}
+var permAddArchivos = '{{ perms.core.add_archivos_facturaproveedor }}';
+if (permAddArchivos !== 'True'){
+    $('input[name="archivos"]').prop('disabled', true);
+}
 $('#id_fecha').datepicker({format: 'dd/mm/yyyy', language: 'es', todayHighlight: true});
 $('#id_proveedor').select2({allowClear: true, language: 'es'});
 $('#id_proveedor').change(function(){

--- a/core/utils/strings.py
+++ b/core/utils/strings.py
@@ -3,7 +3,10 @@
 Contiene mensajes en forma de texto para usuarios.
 """
 
-
+HELP_TEXT_MULTIPLE_CHOICE = """
+Para seleccionar varias opciones, mantenga presionada la tecla Control (Ctrl),
+y haga clic en las opciones que desee seleccionar.
+"""
 HELP_TEXT_PASSWORD_CONFIRMATION = 'Introduzca la misma contraseña nuevamente, para poder verificar la misma.'
 HELP_TEXT_USERNAME = """
 Longitud máxima de {} caracteres. Solo puede estar formado por letras,

--- a/core/utils/strings.py
+++ b/core/utils/strings.py
@@ -16,6 +16,8 @@ MESSAGE_SUCCESS_CREATED = 'El {} ha sido creado exitosamente.'
 MESSAGE_SUCCESS_UPDATE = 'El {} ha sido modificado exitosamente.'
 MESSAGE_SUCCESS_DELETE = 'El {} ha sido eliminado exitosamente.'
 
+MESSAGE_PERMISSION_ERROR = 'No tienes permisos para cambiar este campo.'
+
 _MESSAGE_SUCCESS_CREATED = 'La {} ha sido creada exitosamente.'
 _MESSAGE_SUCCESS_UPDATE = 'La {} ha sido modificada exitosamente.'
 _MESSAGE_SUCCESS_DELETE = 'La {} ha sido eliminada exitosamente.'

--- a/core/views/facturascliente.py
+++ b/core/views/facturascliente.py
@@ -102,12 +102,18 @@ class FacturaListView(PermissionRequiredMixin, SuccessMessageMixin, FilterView):
 class FacturaCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView):
     """Vista para agregar una factura."""
 
-    model = Factura
     form_class = FacturaForm
+    model = Factura
     permission_required = 'core.add_factura'
     raise_exception = True
     success_message = _MESSAGE_SUCCESS_CREATED.format('factura del cliente')
     template_name = 'core/facturacliente_form.html'
+
+    def get_form_kwargs(self):
+        """Envía parámetros extras al formulario."""
+        kwargs = super().get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
 
     def get_success_url(self):
         """Luego de agregar al objecto redirecciono a la vista que tiene permiso."""
@@ -150,6 +156,12 @@ class FacturaUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView
     raise_exception = True
     success_message = _MESSAGE_SUCCESS_UPDATE.format('factura del cliente')
     template_name = 'core/facturacliente_form.html'
+
+    def get_form_kwargs(self):
+        """Envía parámetros extras al formulario."""
+        kwargs = super().get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
 
     def get_success_url(self):
         """Luego de editar al objecto muestra la misma vista."""

--- a/core/views/facturasproveedor.py
+++ b/core/views/facturasproveedor.py
@@ -103,6 +103,12 @@ class FacturaProveedorCreateView(PermissionRequiredMixin, SuccessMessageMixin, C
     raise_exception = True
     success_message = _MESSAGE_SUCCESS_CREATED.format('factura a proveedor')
 
+    def get_form_kwargs(self):
+        """Envía parámetros extras al formulario."""
+        kwargs = super().get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
+
     def get_success_url(self):
         """Luego de agregar al objecto redirecciono a la vista que tiene permiso."""
         if self.request.user.has_perm('core.change_facturaproveedor'):
@@ -142,6 +148,12 @@ class FacturaProveedorUpdateView(PermissionRequiredMixin, SuccessMessageMixin, U
     permission_required = 'core.change_facturaproveedor'
     raise_exception = True
     success_message = _MESSAGE_SUCCESS_UPDATE.format('factura a proveedor')
+
+    def get_form_kwargs(self):
+        """Envía parámetros extras al formulario."""
+        kwargs = super().get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
 
     def get_success_url(self):
         """Luego de editar al objecto muestra la misma vista."""


### PR DESCRIPTION
# Rol: edición de campos en facturas de clientes y proveedores

## Deploy: agregar permisos
- Para agregar los permisos, correr el siguiente comando

      $ docker-compose run --rm app pipenv run python manage.py add_permissions
      
## Rol edición
Para que un rol pueda adjuntar facturas y poner el nro de factura, neto, total, iva **se debe crear un grupo tal como se muestra a continuación y luego agregar al usuario a ese grupo**

![Screenshot_20210204_110628](https://user-images.githubusercontent.com/17284028/106909542-289c3c80-66df-11eb-9016-c829d8c5e1ef.png)

Nota: _El ejemplo es para las facturas a clientes_

Como siempre, los usuarios administradores pueden editar todos los campos sin necesidad de asignarles permisos

A master :rocket: 
