### PR TITLE
Feature/informe retenciones proveedores

### DIFF
--- a/accounting/templates/accounting/pago_list.html
+++ b/accounting/templates/accounting/pago_list.html
@@ -7,6 +7,9 @@
     <!-- Page Heading -->
     <div class="d-sm-flex align-items-center justify-content-between mb-4">
       <h1 class="h3 mb-0 text-gray-800">Pagos a Proveedores</h1>
+      {% if perms.accounting.view_report_retencion_pago %}
+        <a href="{% url 'accounting:pago-list' %}?tipo=retenciones&formato=xls" class="d-none d-sm-inline-block btn btn-sm btn-primary shadow-sm"><i class="fas fa-file-excel fa-sm text-white-50"></i> Retenciones</a>
+      {% endif %}
     </div>
     {% include 'components/messages.html' %}
 

--- a/accounting/views/pagos.py
+++ b/accounting/views/pagos.py
@@ -26,6 +26,7 @@ from accounting.serializers.pagos import PagoSerializer
 
 # Core
 from core.models.proveedor import FacturaProveedor
+from core.utils.export import export_excel
 from core.utils.strings import MESSAGE_403, MESSAGE_SUCCESS_DELETE
 from core.views.home import error_403
 
@@ -51,6 +52,16 @@ class PagoListView(PermissionRequiredMixin, SuccessMessageMixin, ListView):
     paginate_by = 10
     permission_required = 'accounting.list_pago'
     raise_exception = True
+
+    def get(self, request, *args, **kwargs):
+        """Genera reporte en formato excel."""
+        format_list = request.GET.get('formato', False)
+        type_list = request.GET.get('tipo', False)
+
+        if format_list == 'xls' and type_list == 'retenciones':
+            return export_excel(self.request, self.get_queryset())
+
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         """Obtiene datos para incluir en los reportes."""

--- a/accounting/views/pagos.py
+++ b/accounting/views/pagos.py
@@ -10,6 +10,7 @@ from datetime import date
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import PermissionDenied
 from django.db.models import F, Q, Sum
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -59,7 +60,9 @@ class PagoListView(PermissionRequiredMixin, SuccessMessageMixin, ListView):
         type_list = request.GET.get('tipo', False)
 
         if format_list == 'xls' and type_list == 'retenciones':
-            return export_excel(self.request, self.get_queryset())
+            if 'accounting.view_report_retencion_pago' in self.request.user.get_all_permissions():
+                return export_excel(self.request, self.get_queryset())
+            raise PermissionDenied()
 
         return super().get(request, *args, **kwargs)
 

--- a/authorization/management/commands/add_permissions.py
+++ b/authorization/management/commands/add_permissions.py
@@ -72,7 +72,9 @@ class Command(BaseCommand):
                 {'name': 'Puede editar archivos de Facturas A Proveedores',
                  'codename': 'change_archivos_facturaproveedor',
                  'content_type': ContentType.objects.get(model='facturaproveedor')},
-
+                # Pagos
+                {'name': 'Puede exportar retenciones de pagos a Proveedores', 'codename': 'view_report_retencion_pago',
+                 'content_type': ContentType.objects.get(model='pago')},
             ]
 
             for permission in permissions:

--- a/core/utils/export.py
+++ b/core/utils/export.py
@@ -113,6 +113,41 @@ class FacturaProveedorExport(FacturaExport):
         return data
 
 
+class PagoExport():
+    """Clase para exportar pagos a proveedores.
+
+    Args:
+       queryset (django.queryset): queryset de pagos a proveedor.
+    """
+
+    def __init__(self, queryset):
+        """Inicialización de variables."""
+        self.queryset = queryset.order_by('fecha')
+        self.headers = [
+            'pago_nro', 'fecha', 'proveedor', 'retencion_ganancia', 'retencion_ingresos_brutos', 'retencion_iva',
+        ]
+
+    def get_data(self):
+        """Devuelve una lista de pagos a proveedores.
+
+        Returns:
+           list: Obtiene el queryset y genera un lista.
+        """
+        data = []
+
+        for item in self.queryset:
+            data.append([
+                item.pk, item.fecha.strftime('%d/%m/%Y'), item.proveedor.razon_social,
+                item.pago_facturas.all()[0].ganancias, item.pago_facturas.all()[0].ingresos_brutos,
+                item.pago_facturas.all()[0].iva
+            ])
+            for factura in item.pago_facturas.all()[1:]:
+                data.append([
+                    '', '', '', factura.ganancias, factura.ingresos_brutos, factura.iva
+                ])
+        return data
+
+
 def export_excel(request, queryset):
     """Devuelve un archivo en formato excel.
 
@@ -137,6 +172,9 @@ def export_excel(request, queryset):
     elif app == 'facturaproveedor':
         app_export = FacturaProveedorExport(queryset)
         display_dept = True
+    elif app == 'pago':
+        app_export = PagoExport(queryset)
+        display_dept = False
 
     # Encabezados
     for col_num, data in enumerate(app_export.headers):

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Para traducir los permisos correr los comando:
 
     docker-compose run app pipenv run python manage.py permissions_translation
 
-Para agregar los permisos de listar que no viene por defecto:
+Para agregar los permisos:
 
     docker-compose run app pipenv run python manage.py add_permissions
 


### PR DESCRIPTION
# Informe de retenciones de proveedores

## Informe de retenciones
Se agrega un botón para exportar en formato excel un listado de pagos con sus respectivas retenciones

## Permisos
Para que un usuario pueda ver este botón y exportar debe formar parte de un grupo que tenga para permisos para exportar retenciones. 

Ejemplo de un grupo con tales permisos:
![scrnli_12_3_2021 20-55-03](https://user-images.githubusercontent.com/17284028/111010424-3f385200-8375-11eb-977b-0b623950efd3.png)


El usuario administrador por defecto puede realizar la exportación sin necesidad de pertenecer a un grupo con permisos
